### PR TITLE
Add patch that allow run scripts directly without ModuleNotFound when import rendering module

### DIFF
--- a/tutorials/lesson01_math.py
+++ b/tutorials/lesson01_math.py
@@ -1,17 +1,4 @@
-# If file is run as a script add parent directory to path
-# This allow import rendering module
-if __name__ == "__main__":
-    import sys
-    import os
-    import inspect
-
-    currentdir = os.path.dirname(
-        os.path.abspath(inspect.getfile(inspect.currentframe()))
-    )
-    parentdir = os.path.dirname(currentdir)
-    sys.path.insert(0, parentdir)
-    ROOT_DIR = str(parentdir)
-
+import lesson_common
 
 # importing rendering functions.
 import rendering as ren

--- a/tutorials/lesson01_math.py
+++ b/tutorials/lesson01_math.py
@@ -1,3 +1,18 @@
+# If file is run as a script add parent directory to path
+# This allow import rendering module
+if __name__ == "__main__":
+    import sys
+    import os
+    import inspect
+
+    currentdir = os.path.dirname(
+        os.path.abspath(inspect.getfile(inspect.currentframe()))
+    )
+    parentdir = os.path.dirname(currentdir)
+    sys.path.insert(0, parentdir)
+    ROOT_DIR = str(parentdir)
+
+
 # importing rendering functions.
 import rendering as ren
 import numpy as np
@@ -27,11 +42,13 @@ Arguments that are global pointers must be specified as a list. e.g. [np.float32
 Intrinsicly there is a variable with the current thread id. Notice kernels will be invoke for all thread indices from 0 ... num_threads-1 when dispatch.
 """
 
+
 @ren.kernel_main
 def compute(x: [np.float32], y: [np.float32]):
     """
     y[thread_id] = sin(x[thread_id]); // OpenCL has a variety of math functions as builtins
     """
+
 
 # Executing the kernel. name_of_function [ Number of threads ] ( arguments )
 compute[100](x, y)

--- a/tutorials/lesson02_vectors_and_matrices.py
+++ b/tutorials/lesson02_vectors_and_matrices.py
@@ -1,3 +1,18 @@
+# If file is run as a script add parent directory to path
+# This allow import rendering module
+if __name__ == "__main__":
+    import sys
+    import os
+    import inspect
+
+    currentdir = os.path.dirname(
+        os.path.abspath(inspect.getfile(inspect.currentframe()))
+    )
+    parentdir = os.path.dirname(currentdir)
+    sys.path.insert(0, parentdir)
+    ROOT_DIR = str(parentdir)
+
+
 # importing rendering functions.
 import rendering as ren
 import numpy as np
@@ -12,19 +27,38 @@ In rendering an equivalent numpy type is created for each of those builtins.
 
 # Creating the buffer (an opencl buffer in the specific device)
 x = ren.create_buffer(10, ren.float3)
-T = ren.create_struct(ren.float4x4)  # Structs should be passed by value and contains only one element.
+T = ren.create_struct(
+    ren.float4x4
+)  # Structs should be passed by value and contains only one element.
 y = ren.create_buffer(x.shape[0], ren.float3)
 
 with ren.mapped(x) as map:
-    np.copyto(map, np.random.rand(*map.shape, 4).astype(np.float32).ravel().view(ren.float3))
+    np.copyto(
+        map, np.random.rand(*map.shape, 4).astype(np.float32).ravel().view(ren.float3)
+    )
 
 with ren.mapped(T) as map:
-    np.copyto(map, ren.make_float4x4(
-        1.0, 0.0, 0.0, 0.0,
-        0.0, 2.0, 0.0, 0.0,
-        0.0, 0.0, 1.0, 0.0,
-        0.0, 0.0, 0.0, 1.0
-    ))
+    np.copyto(
+        map,
+        ren.make_float4x4(
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            2.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+        ),
+    )
 
 # Creating a kernel to compute the transform
 @ren.kernel_main
@@ -35,8 +69,11 @@ def transform(x: [ren.float3], T: ren.float4x4, y: [ren.float3]):
     y[thread_id] = p.xyz / p.w; // de-homogenize
     """
 
+
 # Executing the kernel. name_of_function [ Number of threads ] ( arguments )
-transform[x.shape](x, T, y)  # if a shape is used, the number of all axis multiplied is assumed.
+transform[x.shape](
+    x, T, y
+)  # if a shape is used, the number of all axis multiplied is assumed.
 
 print(x.get())
 print(y.get())

--- a/tutorials/lesson02_vectors_and_matrices.py
+++ b/tutorials/lesson02_vectors_and_matrices.py
@@ -1,16 +1,4 @@
-# If file is run as a script add parent directory to path
-# This allow import rendering module
-if __name__ == "__main__":
-    import sys
-    import os
-    import inspect
-
-    currentdir = os.path.dirname(
-        os.path.abspath(inspect.getfile(inspect.currentframe()))
-    )
-    parentdir = os.path.dirname(currentdir)
-    sys.path.insert(0, parentdir)
-    ROOT_DIR = str(parentdir)
+import lesson_common
 
 
 # importing rendering functions.

--- a/tutorials/lesson03_drawing_images.py
+++ b/tutorials/lesson03_drawing_images.py
@@ -1,16 +1,4 @@
-# If file is run as a script add parent directory to path
-# This allow import rendering module
-if __name__ == "__main__":
-    import sys
-    import os
-    import inspect
-
-    currentdir = os.path.dirname(
-        os.path.abspath(inspect.getfile(inspect.currentframe()))
-    )
-    parentdir = os.path.dirname(currentdir)
-    sys.path.insert(0, parentdir)
-    ROOT_DIR = str(parentdir)
+import lesson_common
 
 import rendering as ren
 

--- a/tutorials/lesson03_drawing_images.py
+++ b/tutorials/lesson03_drawing_images.py
@@ -1,3 +1,17 @@
+# If file is run as a script add parent directory to path
+# This allow import rendering module
+if __name__ == "__main__":
+    import sys
+    import os
+    import inspect
+
+    currentdir = os.path.dirname(
+        os.path.abspath(inspect.getfile(inspect.currentframe()))
+    )
+    parentdir = os.path.dirname(currentdir)
+    sys.path.insert(0, parentdir)
+    ROOT_DIR = str(parentdir)
+
 import rendering as ren
 
 
@@ -6,14 +20,18 @@ im = ren.create_image2d(6, 4, ren.float4)
 
 # map image memory as a numpy array with shape (4, 6, 4) height, width, components, and dtype = float32
 with ren.mapped(im) as map:
-    map[:,:,0] = 1  # change all red components to 1 as an example of what can be done with the mapped memory.
+    map[
+        :, :, 0
+    ] = 1  # change all red components to 1 as an example of what can be done with the mapped memory.
     print(map)
 # outside the context region (with) the mapped memory is updated to the resource (image).
 
 
 # define a kernel to apply an action for every pixel
 @ren.kernel_main
-def clear_image(im: ren.w_image2d_t):  # the argument is annotated with the image type. In rendering all images are treated as read_write for simplicity.
+def clear_image(
+    im: ren.w_image2d_t,
+):  # the argument is annotated with the image type. In rendering all images are treated as read_write for simplicity.
     """
     int2 dim = get_image_dim(im);
     // in rendering, only linear layout of threads is allowed. Mapping to image positions needs to be done manually.

--- a/tutorials/lesson04_mandelbrot_animation.py
+++ b/tutorials/lesson04_mandelbrot_animation.py
@@ -1,3 +1,18 @@
+# If file is run as a script add parent directory to path
+# This allow import rendering module
+if __name__ == "__main__":
+    import sys
+    import os
+    import inspect
+
+    currentdir = os.path.dirname(
+        os.path.abspath(inspect.getfile(inspect.currentframe()))
+    )
+    parentdir = os.path.dirname(currentdir)
+    sys.path.insert(0, parentdir)
+    ROOT_DIR = str(parentdir)
+
+
 import rendering as ren
 import time
 import numpy as np
@@ -26,6 +41,7 @@ def get_color(m: np.float32) -> ren.float4:
     float s = 2*(1.0f / (1 + exp(-m)) - 0.5f);
     return (float4)(0.0f, 1.0f-s, fmod(s+0.5,1.0), 1.0f);
     """
+
 
 @ren.kernel_main
 def compute_mandelbrot(im: ren.w_image2d_t, info: MandelbrotInfo):
@@ -63,9 +79,13 @@ while True:
     t = time.perf_counter() - start_time
 
     with ren.mapped(mandelbrot_info) as map:
-        map['N'] = 100
-        map['C'] = np.array((0.09 + np.cos(t*0.7)*0.01, 0.61 + np.sin(t)*0.01), dtype=ren.float2)
+        map["N"] = 100
+        map["C"] = np.array(
+            (0.09 + np.cos(t * 0.7) * 0.01, 0.61 + np.sin(t) * 0.01), dtype=ren.float2
+        )
 
-    compute_mandelbrot[presenter.get_render_target().shape](presenter.get_render_target(), mandelbrot_info)
+    compute_mandelbrot[presenter.get_render_target().shape](
+        presenter.get_render_target(), mandelbrot_info
+    )
 
     presenter.present()

--- a/tutorials/lesson04_mandelbrot_animation.py
+++ b/tutorials/lesson04_mandelbrot_animation.py
@@ -1,16 +1,4 @@
-# If file is run as a script add parent directory to path
-# This allow import rendering module
-if __name__ == "__main__":
-    import sys
-    import os
-    import inspect
-
-    currentdir = os.path.dirname(
-        os.path.abspath(inspect.getfile(inspect.currentframe()))
-    )
-    parentdir = os.path.dirname(currentdir)
-    sys.path.insert(0, parentdir)
-    ROOT_DIR = str(parentdir)
+import lesson_common
 
 
 import rendering as ren

--- a/tutorials/lesson05_drawing_points.py
+++ b/tutorials/lesson05_drawing_points.py
@@ -1,3 +1,18 @@
+# If file is run as a script add parent directory to path
+# This allow import rendering module
+if __name__ == "__main__":
+    import sys
+    import os
+    import inspect
+
+    currentdir = os.path.dirname(
+        os.path.abspath(inspect.getfile(inspect.currentframe()))
+    )
+    parentdir = os.path.dirname(currentdir)
+    sys.path.insert(0, parentdir)
+    ROOT_DIR = str(parentdir)
+
+
 import rendering as ren
 import time
 import numpy as np
@@ -11,8 +26,8 @@ In this lesson, a point cloud is rendered after transformation
 # Define a struct to define parameters in the algorithm.
 @ren.kernel_struct
 class Vertex:
-    P: ren.float3   # Position
-    C: ren.float3   # Color
+    P: ren.float3  # Position
+    C: ren.float3  # Color
 
 
 # Create vertex buffer
@@ -22,8 +37,16 @@ vertex_buffer = ren.create_buffer(num_vertex, Vertex)
 # fill vertices with a sphere.
 with ren.mapped(vertex_buffer) as map:
     # the number of float numbers in positions and colors are not 3 floats per vertex but 4 because of the padding imposse to float3
-    map['P'] = np.random.uniform(-1.0, 1.0, size=(num_vertex*4,)).astype(np.float32).view(ren.float3)
-    map['C'] = np.random.uniform(0, 1, size=(num_vertex*4,)).astype(np.float32).view(ren.float3)
+    map["P"] = (
+        np.random.uniform(-1.0, 1.0, size=(num_vertex * 4,))
+        .astype(np.float32)
+        .view(ren.float3)
+    )
+    map["C"] = (
+        np.random.uniform(0, 1, size=(num_vertex * 4,))
+        .astype(np.float32)
+        .view(ren.float3)
+    )
 
 
 @ren.kernel_struct
@@ -80,12 +103,14 @@ while True:
 
     # update the transformation matrices from host every frame
     with ren.mapped(transform_info) as map:
-        map['World'] = ren.scale(0.2 + np.cos(t*4)*0.2, 0.2 + np.sin(t)*0.1, 0.2)
-        map['View'] = ren.translate(0,0,0.3)
-        map['Proj'] = ren.identity()
+        map["World"] = ren.scale(0.2 + np.cos(t * 4) * 0.2, 0.2 + np.sin(t) * 0.1, 0.2)
+        map["View"] = ren.translate(0, 0, 0.3)
+        map["Proj"] = ren.identity()
 
     ren.clear(presenter.get_render_target())
 
-    transform_and_draw[vertex_buffer.shape](presenter.get_render_target(), vertex_buffer, transform_info)
+    transform_and_draw[vertex_buffer.shape](
+        presenter.get_render_target(), vertex_buffer, transform_info
+    )
 
     presenter.present()

--- a/tutorials/lesson05_drawing_points.py
+++ b/tutorials/lesson05_drawing_points.py
@@ -1,16 +1,4 @@
-# If file is run as a script add parent directory to path
-# This allow import rendering module
-if __name__ == "__main__":
-    import sys
-    import os
-    import inspect
-
-    currentdir = os.path.dirname(
-        os.path.abspath(inspect.getfile(inspect.currentframe()))
-    )
-    parentdir = os.path.dirname(currentdir)
-    sys.path.insert(0, parentdir)
-    ROOT_DIR = str(parentdir)
+import lesson_common
 
 
 import rendering as ren

--- a/tutorials/lesson06_loading_obj.py
+++ b/tutorials/lesson06_loading_obj.py
@@ -1,18 +1,4 @@
-ROOT_DIR = "./"  # Used to find the models folder
-
-# If file is run as a script add parent directory to path
-# This allow import rendering module
-if __name__ == "__main__":
-    import sys
-    import os
-    import inspect
-
-    currentdir = os.path.dirname(
-        os.path.abspath(inspect.getfile(inspect.currentframe()))
-    )
-    parentdir = os.path.dirname(currentdir)
-    sys.path.insert(0, parentdir)
-    ROOT_DIR = str(parentdir)
+from lesson_common import ROOT_DIR
 
 import rendering as ren
 import time

--- a/tutorials/lesson06_loading_obj.py
+++ b/tutorials/lesson06_loading_obj.py
@@ -1,3 +1,19 @@
+ROOT_DIR = "./"  # Used to find the models folder
+
+# If file is run as a script add parent directory to path
+# This allow import rendering module
+if __name__ == "__main__":
+    import sys
+    import os
+    import inspect
+
+    currentdir = os.path.dirname(
+        os.path.abspath(inspect.getfile(inspect.currentframe()))
+    )
+    parentdir = os.path.dirname(currentdir)
+    sys.path.insert(0, parentdir)
+    ROOT_DIR = str(parentdir)
+
 import rendering as ren
 import time
 import numpy as np
@@ -9,7 +25,7 @@ In this lesson, a point cloud loaded from a wavefront obj file is rendered after
 
 
 # Load vertex buffer from obj
-visuals = ren.load_obj('../models/dragon.obj')
+visuals = ren.load_obj(f"{ROOT_DIR}/models/dragon.obj")
 mesh, material = visuals[0]
 vertex_buffer = mesh.vertices
 
@@ -26,7 +42,9 @@ transform_info = ren.create_struct(Transforms)
 
 
 @ren.kernel_main
-def transform_and_draw(im: ren.w_image2d_t, vertices: [ren.MeshVertex], info: Transforms):
+def transform_and_draw(
+    im: ren.w_image2d_t, vertices: [ren.MeshVertex], info: Transforms
+):
     """
     int2 dim = get_image_dim(im);
     float3 P = vertices[thread_id].P;
@@ -68,12 +86,20 @@ while True:
 
     # update the transformation matrices from host every frame
     with ren.mapped(transform_info) as map:
-        map['World'] = ren.matmul(ren.scale(1.0), ren.rotate(t, ren.make_float3(0, 1, 0)))
-        map['View'] = ren.look_at(ren.make_float3(0,0.3,2), ren.make_float3(0,0,0), ren.make_float3(0,1,0))
-        map['Proj'] = ren.perspective(aspect_ratio=presenter.width / presenter.height)
+        map["World"] = ren.matmul(
+            ren.scale(1.0), ren.rotate(t, ren.make_float3(0, 1, 0))
+        )
+        map["View"] = ren.look_at(
+            ren.make_float3(0, 0.3, 2),
+            ren.make_float3(0, 0, 0),
+            ren.make_float3(0, 1, 0),
+        )
+        map["Proj"] = ren.perspective(aspect_ratio=presenter.width / presenter.height)
 
     ren.clear(presenter.get_render_target())
 
-    transform_and_draw[vertex_buffer.shape](presenter.get_render_target(), vertex_buffer, transform_info)
+    transform_and_draw[vertex_buffer.shape](
+        presenter.get_render_target(), vertex_buffer, transform_info
+    )
 
     presenter.present()

--- a/tutorials/lesson_common.py
+++ b/tutorials/lesson_common.py
@@ -1,0 +1,10 @@
+# If file is run as a script add parent directory to path
+# This allow import rendering module
+import sys
+import os
+import inspect
+
+currentdir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+parentdir = os.path.dirname(currentdir)
+sys.path.insert(0, parentdir)
+ROOT_DIR = str(parentdir)


### PR DESCRIPTION
When traying to run a tutorial script `ModuleNotFound` exception can happens if environment don't have the root directory in the `PYTHONPATH`.

This patch check if the script is running as main process (Was executed directly with `python lesson*.py` or from project's root as `python tutorials/lesson*.py` ) and adds the project's root directory to the system path.